### PR TITLE
updating to 0.0.1-alpha.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.1-alpha.2] - 2025-08-03
+
+### Added
+- Fixed logo in docs
+- Added TODOs to README
+- Fixes for the installers
+
 ## [0.0.1-alpha.1] - 2025-08-03
 
 ### Added
@@ -25,4 +32,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Limited to G.711 codecs (Opus support planned)
 - No TLS or TCP transport support yet
 
-[0.0.1-alpha.1]: https://github.com/parrot-platform/parrot_platform/releases/tag/v0.0.1-alpha.1

--- a/installer/parrot_new/README.md
+++ b/installer/parrot_new/README.md
@@ -15,7 +15,7 @@ Or from GitHub before Hex publication:
 git clone https://github.com/parrot-platform/parrot_platform.git
 cd parrot/installer/parrot_new
 mix archive.build
-mix archive.install ./parrot_new-0.0.1-alpha.1.ez
+mix archive.install ./parrot_new-0.0.1-alpha.2.ez
 ```
 
 ## Usage

--- a/installer/parrot_new/lib/mix/tasks/parrot.gen.uac.ex
+++ b/installer/parrot_new/lib/mix/tasks/parrot.gen.uac.ex
@@ -156,7 +156,7 @@ defmodule Mix.Tasks.Parrot.Gen.Uac do
 
       defp deps do
         [
-          {:parrot_platform, "~> 0.0.1-alpha.1"}
+          {:parrot_platform, "~> 0.0.1-alpha.2"}
         ]
       end
     end

--- a/installer/parrot_new/lib/mix/tasks/parrot.gen.uas.ex
+++ b/installer/parrot_new/lib/mix/tasks/parrot.gen.uas.ex
@@ -704,7 +704,7 @@ defmodule Mix.Tasks.Parrot.Gen.Uas do
       # Run "mix help deps" to learn about dependencies.
       defp deps do
         [
-          {:parrot_platform, "~> 0.0.1-alpha.1"}
+          {:parrot_platform, "~> 0.0.1-alpha.2"}
         ]
       end
     end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Parrot.MixProject do
   def project do
     [
       app: :parrot_platform,
-      version: "0.0.1-alpha.1",
+      version: "0.0.1-alpha.2",
       elixir: "~> 1.16",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
@@ -90,11 +90,12 @@ defmodule Parrot.MixProject do
   defp copy_images(_) do
     # Ensure doc directory exists
     File.mkdir_p!("doc/assets")
-    
+
     # Copy logo and any other assets from assets/ to doc/assets/
     case File.cp_r("assets", "doc/assets") do
       {:ok, _} ->
         Mix.shell().info("Copied assets to doc/assets")
+
       {:error, reason, file} ->
         Mix.shell().error("Failed to copy #{file}: #{inspect(reason)}")
     end


### PR DESCRIPTION
This pull request updates the project version to `0.0.1-alpha.2` and includes associated changes to documentation, dependencies, and version references. It also introduces minor updates to project files for consistency.

### Version update and dependency changes:
* Updated project version from `0.0.1-alpha.1` to `0.0.1-alpha.2` in `mix.exs`.
* Updated dependency references in `installer/parrot_new/lib/mix/tasks/parrot.gen.uac.ex` and `installer/parrot_new/lib/mix/tasks/parrot.gen.uas.ex` to use `~> 0.0.1-alpha.2`. [[1]](diffhunk://#diff-e74cb4a0bca0c59039cd36da7490946eb7cb04a8d0e5856620f15010928f8135L159-R159) [[2]](diffhunk://#diff-be6b9e61183433b07191d4f477231b6e0049614325a4ef82b820e3765000b90bL707-R707)
* Updated the installer command in `installer/parrot_new/README.md` to reference the new version.

### Documentation updates:
* Added a new section for version `0.0.1-alpha.2` in `CHANGELOG.md`, documenting fixes for the logo, README TODOs, and installers.

### Minor project adjustments:
* Added a blank line for readability in the `mix.exs` file under the asset copying logic.