### PR TITLE
feat(media): inbound-audio tap — stream the remote leg to a handler callback

### DIFF
--- a/lib/parrot/media/audio_tap_sink.ex
+++ b/lib/parrot/media/audio_tap_sink.ex
@@ -1,0 +1,42 @@
+defmodule Parrot.Media.AudioTapSink do
+  @moduledoc """
+  A Membrane sink that forwards each inbound audio buffer to a target process as
+  `{:parrot_audio_frame, ssrc, pcm}`.
+
+  Drop-in replacement for the discard-only `Membrane.Debug.Sink` on the *receive*
+  path, so an application can tap the decoded remote-leg audio — e.g. stream it
+  to a transcriber, recorder, or VAD — without owning the media pipeline.
+
+  `Parrot.Media.MembraneAlawPipeline` wires this sink in automatically when the
+  session's media handler implements `c:Parrot.MediaHandler.handle_audio_frame/3`;
+  otherwise it keeps the original `Membrane.Debug.Sink` (no behaviour change).
+  """
+  use Membrane.Sink
+
+  alias Membrane.Buffer
+
+  def_input_pad(:input, accepted_format: _any, flow_control: :auto)
+
+  def_options(
+    target: [
+      spec: pid(),
+      description: "Process that receives `{:parrot_audio_frame, ssrc, pcm}` messages."
+    ],
+    ssrc: [
+      spec: term(),
+      default: nil,
+      description: "SSRC of the inbound RTP stream this sink drains."
+    ]
+  )
+
+  @impl true
+  def handle_init(_ctx, opts) do
+    {[], %{target: opts.target, ssrc: opts.ssrc}}
+  end
+
+  @impl true
+  def handle_buffer(:input, %Buffer{payload: payload}, _ctx, state) do
+    send(state.target, {:parrot_audio_frame, state.ssrc, payload})
+    {[], state}
+  end
+end

--- a/lib/parrot/media/membrane_alaw_pipeline.ex
+++ b/lib/parrot/media/membrane_alaw_pipeline.ex
@@ -229,6 +229,16 @@ defmodule Parrot.Media.MembraneAlawPipeline do
 
     Logger.debug("  Full notification: #{inspect(notification)}")
 
+    # Drain the decoded inbound audio. When the session's media handler taps
+    # audio, forward each frame to it via AudioTapSink; otherwise keep the
+    # original discard-only Debug.Sink (no behaviour change).
+    audio_sink =
+      if tap_audio?(state) do
+        %Parrot.Media.AudioTapSink{target: self(), ssrc: ssrc}
+      else
+        %Membrane.Debug.Sink{}
+      end
+
     # Create a pipeline to handle incoming RTP audio
     receive_audio_spec = [
       get_child(:rtp)
@@ -236,7 +246,7 @@ defmodule Parrot.Media.MembraneAlawPipeline do
         options: [depayloader: Membrane.RTP.G711.Depayloader]
       )
       |> child({:g711_decoder, ssrc}, Membrane.G711.Decoder)
-      |> child({:audio_sink, ssrc}, %Membrane.Debug.Sink{})
+      |> child({:audio_sink, ssrc}, audio_sink)
     ]
 
     {[spec: receive_audio_spec], state}
@@ -246,6 +256,34 @@ defmodule Parrot.Media.MembraneAlawPipeline do
   def handle_child_notification(_notification, _child, _ctx, state) do
     {[], state}
   end
+
+  # AudioTapSink (its own element process) forwards each decoded inbound PCM
+  # buffer here; relay it to the session's media handler. Runs on the pipeline
+  # process, so the handler callback must stay non-blocking.
+  @impl true
+  def handle_info({:parrot_audio_frame, ssrc, pcm}, _ctx, state) do
+    if tap_audio?(state) do
+      frame = %{ssrc: ssrc, pcm: pcm}
+
+      case state.media_handler.handle_audio_frame(state.session_id, frame, state.handler_state) do
+        {:ok, handler_state} -> {[], %{state | handler_state: handler_state}}
+        _other -> {[], state}
+      end
+    else
+      {[], state}
+    end
+  end
+
+  @impl true
+  def handle_info(_msg, _ctx, state), do: {[], state}
+
+  # True when the session's media handler opts into inbound-audio taps by
+  # implementing handle_audio_frame/3.
+  defp tap_audio?(%{media_handler: handler}) when is_atom(handler) and not is_nil(handler) do
+    Code.ensure_loaded?(handler) and function_exported?(handler, :handle_audio_frame, 3)
+  end
+
+  defp tap_audio?(_state), do: false
 
   defp parse_ip(ip) when is_binary(ip) do
     case :inet.parse_address(String.to_charlist(ip)) do

--- a/lib/parrot/media_handler.ex
+++ b/lib/parrot/media_handler.ex
@@ -445,6 +445,35 @@ defmodule Parrot.MediaHandler do
   @callback handle_media_request(request :: term(), state) ::
               media_action() | {media_action(), state} | {:error, reason :: term(), state}
 
+  @doc """
+  Handle a decoded inbound audio frame from the remote leg.
+
+  Called for each decoded PCM buffer received on the inbound RTP stream, when
+  the media pipeline is tapping audio. Implement it to stream the remote
+  party's audio to a transcriber, recorder, or VAD — defining this callback is
+  what opts a session into the tap (otherwise inbound audio is discarded, as
+  before).
+
+  Runs on the media-pipeline process, so keep it non-blocking: hand the frame
+  to another process for heavy work (e.g. Whisper) rather than transcribing
+  inline.
+
+  ## Parameters
+
+  - `session_id` - Session identifier
+  - `audio_frame` - `%{ssrc: term(), pcm: binary()}` decoded PCM (signed 16-bit)
+  - `state` - Current handler state
+
+  ## Returns
+
+  - `{:ok, state}` - Acknowledged
+  """
+  @callback handle_audio_frame(
+              session_id,
+              audio_frame :: %{ssrc: term(), pcm: binary()},
+              state
+            ) :: {:ok, state}
+
   # Optional callbacks - all except init
   @optional_callbacks [
     handle_session_start: 3,
@@ -457,6 +486,7 @@ defmodule Parrot.MediaHandler do
     handle_stream_stop: 3,
     handle_stream_error: 3,
     handle_play_complete: 2,
-    handle_media_request: 2
+    handle_media_request: 2,
+    handle_audio_frame: 3
   ]
 end

--- a/test/parrot/media/audio_tap_sink_test.exs
+++ b/test/parrot/media/audio_tap_sink_test.exs
@@ -1,0 +1,31 @@
+defmodule Parrot.Media.AudioTapSinkTest do
+  use ExUnit.Case, async: true
+
+  alias Membrane.Buffer
+  alias Parrot.Media.AudioTapSink
+
+  test "handle_init keeps the target pid and ssrc" do
+    opts = %AudioTapSink{target: self(), ssrc: 42}
+    assert {[], state} = AudioTapSink.handle_init(%{}, opts)
+    assert state.target == self()
+    assert state.ssrc == 42
+  end
+
+  test "handle_buffer forwards the payload to the target as {:parrot_audio_frame, ssrc, pcm}" do
+    state = %{target: self(), ssrc: 7}
+    buffer = %Buffer{payload: <<1, 2, 3, 4>>}
+
+    assert {[], ^state} = AudioTapSink.handle_buffer(:input, buffer, %{}, state)
+    assert_receive {:parrot_audio_frame, 7, <<1, 2, 3, 4>>}
+  end
+
+  test "each buffer produces its own frame message (order preserved)" do
+    state = %{target: self(), ssrc: :leg_a}
+
+    AudioTapSink.handle_buffer(:input, %Buffer{payload: <<1>>}, %{}, state)
+    AudioTapSink.handle_buffer(:input, %Buffer{payload: <<2>>}, %{}, state)
+
+    assert_receive {:parrot_audio_frame, :leg_a, <<1>>}
+    assert_receive {:parrot_audio_frame, :leg_a, <<2>>}
+  end
+end


### PR DESCRIPTION
## What

Adds an **opt-in inbound-audio tap** so an application can consume the decoded audio of the remote (inbound) RTP leg.

Today the receive path in `Parrot.Media.MembraneAlawPipeline` depayloads + decodes inbound RTP to PCM and then drops it into a discard-only `Membrane.Debug.Sink` — there's no public way to get at the remote party's audio (for transcription, recording, VAD, etc.). This wires a clean, backward-compatible tap.

## Changes

- **`Parrot.Media.AudioTapSink`** (new) — a `Membrane.Sink` that forwards each inbound PCM buffer to a target process as `{:parrot_audio_frame, ssrc, pcm}`.
- **`Parrot.Media.MembraneAlawPipeline`** — on a new inbound RTP stream, use `AudioTapSink` instead of `Debug.Sink` **only when** the session's media handler implements `handle_audio_frame/3`, and relay tapped frames to it via the pipeline's `handle_info/3`. Handlers that don't implement the callback are completely unaffected (still `Debug.Sink`).
- **`Parrot.MediaHandler.handle_audio_frame/3`** (new, optional callback) — the public API to consume the remote leg's decoded audio. Runs on the pipeline process, so it's documented to hand frames off (e.g. to a transcriber) rather than block.
- **Test** — `Parrot.Media.AudioTapSinkTest`.

## Backward compatibility

Fully additive. The new callback is in `@optional_callbacks`; existing handlers compile and behave exactly as before. The tap only activates when a handler opts in by defining `handle_audio_frame/3`.

## Example

```elixir
@impl Parrot.MediaHandler
def handle_audio_frame(_session_id, %{ssrc: ssrc, pcm: pcm}, state) do
  # hand the remote leg's audio to a transcriber / recorder / VAD
  send(state.transcriber, {:pcm, ssrc, pcm})
  {:ok, state}
end
```

## Verification

`mix compile` clean; `mix test test/parrot/media/audio_tap_sink_test.exs test/parrot/media/media_handler_test.exs` → 20 tests, 0 failures.

## Motivation

Building a call relay that bridges a call and streams the far side into speech-to-text; the inbound-audio tap was the one missing primitive.